### PR TITLE
Make invoice list implementation conform

### DIFF
--- a/pmpro-pdf-invoices.php
+++ b/pmpro-pdf-invoices.php
@@ -487,6 +487,11 @@ function pmpropdf_download_list_shortcode_handler(){
 
 		if(!empty($invoices)){
 			foreach ($invoices as $key => $invoice) {
+				$invoice_id = $invoice->id;
+				$invoice = new MemberOrder;
+				$invoice->getMemberOrderByID($invoice_id);
+				$invoice->getMembershipLevel();
+
 				if ( file_exists( pmpropdf_get_invoice_directory_or_url() . pmpropdf_generate_invoice_name($invoice->code) ) ){
 					$content .= '<tr>';
 					$content .=		'<td>' . date_i18n(get_option("date_format"), $invoice->timestamp) . '</td>';


### PR DESCRIPTION
If you check the pmpro function that lists the invoices in user area, you will see these exact rows.
This must be applied to make your invoice list implementation conform with the one from pmpro.
Also, this one solves the issue reported a few days ago about different dates in pmpro default invoice list view and your invoice list view.