### PR TITLE
Fix column name for column "Download PDF"

### DIFF
--- a/pmpro-pdf-invoices.php
+++ b/pmpro-pdf-invoices.php
@@ -502,7 +502,7 @@ function pmpropdf_download_list_shortcode_handler(){
 			$table_content .= 	"<thead>";
 			$table_content .= 		"<tr>";
 			$table_content .= 			"<th>" . __("Date", 'pmpro-pdf-invoices' ) . "</th>";
-			$table_content .= 			"<th>" . __("Level", 'pmpro-pdf-invoices' ) . "</th>";
+			$table_content .= 			"<th>" . __("Download", 'pmpro-pdf-invoices' ) . "</th>";
 			$table_content .= 		"</tr>";
 			$table_content .= 	"</thead>";
 			$table_content .= 	"<tbody>";


### PR DESCRIPTION
This issue is probably from a copy and paste from pmpro.
The correct column name should be "Download", not "Label".