### PR TITLE
Proposal: show pdf filename

### DIFF
--- a/pmpro-pdf-invoices.php
+++ b/pmpro-pdf-invoices.php
@@ -490,7 +490,7 @@ function pmpropdf_download_list_shortcode_handler(){
 				if ( file_exists( pmpropdf_get_invoice_directory_or_url() . pmpropdf_generate_invoice_name($invoice->code) ) ){
 					$content .= '<tr>';
 					$content .=		'<td>' . date_i18n(get_option("date_format"), $invoice->timestamp) . '</td>';
-					$content .= 	'<td><a href="' . esc_url( admin_url( '?pmpropdf=' . $invoice->code ) ). '">' . __( 'Download PDF', 'pmpro-pdf-invoices' ) .'</a></td>';
+					$content .= 	'<td><a href="' . esc_url( admin_url( '?pmpropdf=' . $invoice->code ) ). '">' . pmpropdf_generate_invoice_name( $invoice->code ) .'</a></td>';
 					$content .= '</tr>';
 				}
 			}


### PR DESCRIPTION
I think you should show the filename instead of a generic "Download PDF" label for files, because:
1) When you have more than one invoice, it's an infinite list of not-so-informative "Download PDF" buttons
2) If I download more than one invoice, I can't see which row is related to every downloaded files.