### PR TITLE
Update pmpro-pdf-invoices.php

### DIFF
--- a/pmpro-pdf-invoices.php
+++ b/pmpro-pdf-invoices.php
@@ -102,8 +102,13 @@ include( PMPRO_PDF_DIR . '/includes/dompdf/autoload.inc.php' );
  * Return new attachments array to the PMPro email attachment hook
 */
 function pmpropdf_attach_pdf_email( $attachments, $email ) {
-	// Let's not send it to admins and only with checkout emails.
-	if ( strpos( $email->template, "checkout_" ) !== false && strpos( $email->template, "admin" ) !== false && strpos( $email->template, "invoice" ) !== false ) {
+	// Let's not send it to admins
+	if( strpos( $email->template, "admin" ) !== false ){
+		return $attachments;
+	}
+
+	// Let's send it only with checkout emails and invoice email
+	if( strpos( $email->template, "checkout_" ) === false && $email->template != 'invoice' ) {
 		return $attachments;
 	}
 


### PR DESCRIPTION
Fix the "don't send to" login.

The logic should be:
- dont send if template contains admin
- dont send if template is not invoice AND does not contain checkout_

The old login (wrong) instead was: dont send if
- contains checkout_ AND contains admin AND contains invoice
...doesn't make any sense.