### PR TITLE
Datetime consistency

### DIFF
--- a/pmpro-pdf-invoices.php
+++ b/pmpro-pdf-invoices.php
@@ -183,7 +183,15 @@ function pmpropdf_generate_pdf($order_data){
 		$billing_details = '';
 	}
 
-	$date = isset( $order_data->timestamp) ? new DateTime( $order_data->timestamp ) : new DateTime();
+	$datetime = "";
+	if(empty($order_data->datetime) && empty($order_data->timestamp))
+		$datetime = date("Y-m-d H:i:s", time());
+	elseif(empty($order_data->datetime) && !empty($order_data->timestamp) && is_numeric($order_data->timestamp))
+		$datetime = date("Y-m-d H:i:s", $order_data->timestamp);	//get datetime from timestamp
+	elseif(empty($order_data->datetime) && !empty($order_data->timestamp))
+		$datetime = $order_data->timestamp;		//must have a datetime in it
+
+	$date = new DateTime( $datetime );
 	$date = $date->format( "Y-m-d" );
 
 	$payment_method = !empty( $order_data->gateway ) ? $order_data->gateway : __( 'N/A', 'pmpro-pdf-invoices');


### PR DESCRIPTION
Please consider that the pdf generation may happen alter, not when order is created only.
That's why you must assume the $order_data is a MemberOrder object.

That said, datetime parse (with new DateTime) must be consistent with the various ways it can be set.
Can be a complete timestamp, but can also be a time in seconds.
