### PR TITLE
Billing data consistency

### DIFF
--- a/pmpro-pdf-invoices.php
+++ b/pmpro-pdf-invoices.php
@@ -171,14 +171,14 @@ function pmpropdf_generate_pdf($order_data){
 
 
 	// Build the string for billing data.
-	if ( ! empty( $order_data->billing_name ) ) {
+	if ( ! empty( $order_data->billing->name ) ) {
 		$billing_details = "<p><strong>" . __( 'Billing Details', 'pmpro-pdf-invoices' ) . "</strong></p>";
-		$billing_details .= "<p>" . $order_data->billing_name . "<br/>";
-		$billing_details .=  $order_data->billing_street . "<br/>";
-		$billing_details .= $order_data->billing_city . "<br/>";
-		$billing_details .= $order_data->billing_state . "<br/>";
-		$billing_details .= $order_data->billing_country . "<br/>";
-		$billing_details .= $order_data->billing_phone . "</p>";
+		$billing_details .= "<p>" . $order_data->billing->name . "<br/>";
+		$billing_details .=  $order_data->billing->street . "<br/>";
+		$billing_details .= $order_data->billing->city . "<br/>";
+		$billing_details .= $order_data->billing->state . "<br/>";
+		$billing_details .= $order_data->billing->country . "<br/>";
+		$billing_details .= $order_data->billing->phone . "</p>";
 	} else {
 		$billing_details = '';
 	}


### PR DESCRIPTION
Similar to what already explained in pull request https://github.com/Yoohoo-Plugins/pmpro-pdf-invoices/pull/19.

The billing data with the unserscore (i.e. billing_name) exists just when the order is added.
The correct structure is billing->name, billing->street and so on.

This one works both on order creation and when the pdf invoice generation is called later on passing a MemberOrder instance.