### PR TITLE
Special Character Support

### DIFF
--- a/pmpro-pdf-invoices.php
+++ b/pmpro-pdf-invoices.php
@@ -185,9 +185,21 @@ function pmpropdf_generate_pdf($order_data, $return_dom_pdf = false){
 
 	$user = get_user_by('ID', $order_data->user_id);
 
-	$dompdf = new Dompdf( array( 'enable_remote' => true ) );
+	$options = new Options();
 
-	$body = pmpropdf_get_order_template_html();
+	/**
+	 * DejaVu Sans: works well for cyrillic characters
+	 * DroidSansFallbackFull: works well for chinese characters
+	 * 
+	 */
+	
+	if( has_filter( 'pmpro_pdf_dompdf_default_font' ) ) {
+		$options->setDefaultFont( apply_filters( 'pmpro_pdf_dompdf_default_font', 'DejaVu Sans' ) );
+	}
+	
+	$dompdf = new Dompdf( array( 'enable_remote' => true ) );
+	
+	$dompdf->setOptions($options);
 
 	// Build the string for billing data.
 	if ( ! empty( $order_data->billing_name ) ) {


### PR DESCRIPTION
- Dompdf has been updated to 2.0.0 [NEEDS TO BE DONE]
- Support for special characters has been added

Different characters require different fonts to render. 

After testing with the following string in the PDF:

test 简化字 彝語/彝语 test číslo € černý Češký

There are two fonts that work for this combination. 

DejaVu Sans: works well for cyrillic characters
DroidSansFallbackFull: works well for chinese characters

A new filter has been introduced called `pmpro_pdf_dompdf_default_font` and accepts 1 parameter: a font name

![image](https://user-images.githubusercontent.com/8989542/188960477-66aa9083-948d-4753-9dbc-c96fe0d2de55.png)
DejaVu Sans will break Chinese characters. It doesn't show ?? marks but it doesn't render anything

![image](https://user-images.githubusercontent.com/8989542/188960446-220f93a0-111a-4490-aaa8-10481ff9b6c9.png)
DroidSansFallbackFull renders Chinese Characters but cyril characters are shown as blocks.

