### PR TITLE
Fixes downloading an invoice and nothing happening

### DIFF
--- a/pmpro-pdf-invoices.php
+++ b/pmpro-pdf-invoices.php
@@ -489,7 +489,9 @@ function pmpropdf_download_invoice( $order_code ) {
 
 		$download_url .= "?access=$access_key";
 
-		header("Location: " . $download_url);
+		header('Content-type: application/pdf');
+		header('Content-Disposition: attachment; filename="'.$invoice_name.'"');
+		readfile($download_url);
 
 		/**
 		 * This is removed to support the force htaccess redirect


### PR DESCRIPTION
Some sites have experienced an issue where clicking on the Download Invoice link opens and closes a new tab but the PDF doesn't download. 

The attached fix applies a workaround for this. 