### PR TITLE
Compat PHP 8.2: avoid declaring dynamic properties

### DIFF
--- a/includes/class.pmpro-pdf-invoice-updater.php
+++ b/includes/class.pmpro-pdf-invoice-updater.php
@@ -17,6 +17,7 @@ class PMPro_PDF_Invoice_Updater {
 	private $slug        = '';
 	private $version     = '';
 	private $wp_override = false;
+	private $beta        = false;
 	private $cache_key   = '';
 
 	/**


### PR DESCRIPTION
This will avoid the deprecation notice:

> Creation of dynamic property PMPro_PDF_Invoice_Updater::$beta is deprecated